### PR TITLE
fix: Static assets build issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Install Tailwind dependencies and build
+RUN npm i
 RUN python manage.py tailwind install
-RUN npm i tailwindcss daisyui@latest
 RUN python manage.py tailwind build
 
 # Run the application

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ clean: ## Remove all containers, volumes, and images
 ps: ## Show running containers
 	docker compose ps
 
+twbuild:
+	docker compose exec web npm i
+	docker compose exec web python manage.py tailwind install
+	docker compose exec web python manage.py tailwind build
+
 twstart:
 	docker compose exec web python manage.py tailwind start
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ twbuild:
 	docker compose exec web npm i
 	docker compose exec web python manage.py tailwind install
 	docker compose exec web python manage.py tailwind build
+	docker compose restart
 
 twstart:
 	docker compose exec web python manage.py tailwind start

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ clean: ## Remove all containers, volumes, and images
 ps: ## Show running containers
 	docker compose ps
 
-
 twstart:
 	docker compose exec web python manage.py tailwind start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
+      - /app/node_modules
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,7 @@ services:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - ./db.sqlite3:/app/db.sqlite3
-      - ./Makefile:/app/Makefile
-      - ./theme:/app/theme
-      - ./users:/app/users
-      - ./jobs:/app/jobs
-      - ./jobs_v2:/app/jobs_v2
-      - ./manage.py:/app/manage.py
+      - .:/app
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
+      - node_modules:/app/node_modules
     ports:
       - "8000:8000"
     environment:
@@ -23,3 +24,4 @@ services:
 
 volumes:
   postgres_data: 
+  node_modules: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,9 @@
-version: '3.8'
-
 services:
   web:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
-      - /app/node_modules
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,13 @@ services:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/app
-      - node_modules:/app/node_modules
+      - ./db.sqlite3:/app/db.sqlite3
+      - ./Makefile:/app/Makefile
+      - ./theme:/app/theme
+      - ./users:/app/users
+      - ./jobs:/app/jobs
+      - ./jobs_v2:/app/jobs_v2
+      - ./manage.py:/app/manage.py
     ports:
       - "8000:8000"
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "jobs-v2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,9 @@
   "packages": {
     "": {
       "dependencies": {
+        "daisyui": "^5.0.0",
         "tailwind": "^4.0.0",
         "tailwindcss": "^4.0.9"
-      },
-      "devDependencies": {
-        "daisyui": "^5.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -499,7 +497,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.0.tgz",
       "integrity": "sha512-U0K9Bac3Bi3zZGm6ojrw12F0vBHTpEgf46zv/BYxLe07hF0Xnx7emIQliwaRBgJuYhY0BhwQ6wSnq5cJXHA2yA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/saadeghi/daisyui?sponsor=1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jobs-v2",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
-  "devDependencies": {
-    "daisyui": "^5.0.0"
-  },
   "dependencies": {
     "tailwind": "^4.0.0",
-    "tailwindcss": "^4.0.9"
+    "tailwindcss": "^4.0.9",
+    "daisyui": "^5.0.0"
   }
 }


### PR DESCRIPTION
The issue was on `docker compose up`, since the local source code is volumized, the `node_modules/` directory is getting replaced by what is in the local which causes the missing node packages.

The fix is to mount an anonymous persistent volume.